### PR TITLE
refactor: externalize sidebar link definitions

### DIFF
--- a/components/app/sidebar.vue
+++ b/components/app/sidebar.vue
@@ -1,16 +1,10 @@
 <script setup lang="ts">
+import sidebarLinks from "~/constants/sidebar-links";
+
 const sidebar = useControlBarStore();
 const route = useRoute();
 
-const links = [
-  { type: "link", icon: "tabler:home", text: "Home", to: "/dashboard" },
-  { type: "group", icon: "tabler:map", text: "Locations", data: [
-    { type: "link", icon: "tabler:map-pin-2", text: "All Locations", to: "/dashboard/locations" },
-    { type: "link", icon: "tabler:map-pin-filled", text: "My Locations", to: "/dashboard/locations/my-locations" },
-    { type: "link", icon: "tabler:map-pin-plus", text: "Add Location", to: "/dashboard/locations?add=true" },
-  ] },
-  { type: "link", icon: "solar:gallery-minimalistic-bold", text: "Gallery", to: "/dashboard/gallery" },
-];
+const links = sidebarLinks;
 </script>
 
 <template>

--- a/constants/sidebar-links.ts
+++ b/constants/sidebar-links.ts
@@ -1,0 +1,36 @@
+export const sidebarLinks = [
+  { type: "link", icon: "tabler:home", text: "Home", to: "/dashboard" },
+  {
+    type: "group",
+    icon: "tabler:map",
+    text: "Locations",
+    data: [
+      {
+        type: "link",
+        icon: "tabler:map-pin-2",
+        text: "All Locations",
+        to: "/dashboard/locations",
+      },
+      {
+        type: "link",
+        icon: "tabler:map-pin-filled",
+        text: "My Locations",
+        to: "/dashboard/locations/my-locations",
+      },
+      {
+        type: "link",
+        icon: "tabler:map-pin-plus",
+        text: "Add Location",
+        to: "/dashboard/locations?add=true",
+      },
+    ],
+  },
+  {
+    type: "link",
+    icon: "solar:gallery-minimalistic-bold",
+    text: "Gallery",
+    to: "/dashboard/gallery",
+  },
+];
+
+export default sidebarLinks;


### PR DESCRIPTION
## Summary
- keep `sidebar` links in new `constants/sidebar-links.ts`
- import and use the shared config in `sidebar.vue`

## Testing
- `pnpm lint` *(fails: unable to fetch pnpm)*

------
https://chatgpt.com/codex/tasks/task_e_6848422cb84483308a86505ae6047f89