### PR TITLE
Add modal delay after route navigation

### DIFF
--- a/pages/dashboard/locations/index.vue
+++ b/pages/dashboard/locations/index.vue
@@ -13,11 +13,34 @@ definePageMeta({
 
 const router = useRouter();
 const route = useRoute();
+const previousRoute = useState<string | null>('previousRoute');
 const showAddModal = ref(false);
 
-watchEffect(() => {
-  showAddModal.value = route.query.add === "true";
-});
+let delayTimeout: ReturnType<typeof setTimeout> | null = null;
+
+watch(
+  () => route.query.add,
+  (val) => {
+    if (delayTimeout) {
+      clearTimeout(delayTimeout);
+      delayTimeout = null;
+    }
+    if (val === 'true') {
+      const cameFromAnotherRoute =
+        previousRoute.value && previousRoute.value.split('?')[0] !== route.path;
+      if (cameFromAnotherRoute) {
+        delayTimeout = setTimeout(() => {
+          showAddModal.value = true;
+        }, 250);
+      } else {
+        showAddModal.value = true;
+      }
+    } else {
+      showAddModal.value = false;
+    }
+  },
+  { immediate: true }
+);
 
 const LocationSchema = z.object({
   name: z.string().min(1, "Name is required"),

--- a/plugins/route-history.client.ts
+++ b/plugins/route-history.client.ts
@@ -1,0 +1,7 @@
+export default defineNuxtPlugin(() => {
+  const previousRoute = useState<string | null>('previousRoute', () => null);
+  const router = useRouter();
+  router.afterEach((to, from) => {
+    previousRoute.value = from.fullPath;
+  });
+});


### PR DESCRIPTION
## Summary
- track previous route via new plugin
- delay location modal opening when coming from another route

## Testing
- `pnpm lint` *(fails: fetch error)*

------
https://chatgpt.com/codex/tasks/task_e_68484450fdb48330814ec176f24d8448