### PR TITLE
Implement location creation API

### DIFF
--- a/server/api/locations/index.get.ts
+++ b/server/api/locations/index.get.ts
@@ -1,0 +1,18 @@
+import { auth } from "~/lib/auth";
+import db from "~/lib/db";
+import { location } from "~/lib/db/schema";
+import { eq } from "drizzle-orm";
+
+export default defineEventHandler(async (event) => {
+  const session = await auth.api.getSession({ headers: event.headers });
+  if (!session?.user) {
+    throw createError({ statusCode: 401, statusMessage: "Unauthorized" });
+  }
+
+  const locations = await db
+    .select()
+    .from(location)
+    .where(eq(location.userId, session.user.id));
+
+  return locations;
+});

--- a/server/api/locations/index.post.ts
+++ b/server/api/locations/index.post.ts
@@ -1,0 +1,48 @@
+import { auth } from "~/lib/auth";
+import db from "~/lib/db";
+import { location } from "~/lib/db/schema";
+import { z } from "zod";
+
+const LocationSchema = z.object({
+  name: z.string().min(1),
+  description: z.string().optional(),
+  lat: z.number().min(-90).max(90),
+  long: z.number().min(-180).max(180),
+});
+
+function slugify(text: string) {
+  return text
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+export default defineEventHandler(async (event) => {
+  const session = await auth.api.getSession({ headers: event.headers });
+  if (!session?.user) {
+    throw createError({ statusCode: 401, statusMessage: "Unauthorized" });
+  }
+
+  const body = await readBody(event);
+  const result = LocationSchema.safeParse(body);
+  if (!result.success) {
+    throw createError({ statusCode: 400, statusMessage: "Invalid data" });
+  }
+
+  const data = result.data;
+
+  const [newLocation] = await db
+    .insert(location)
+    .values({
+      name: data.name,
+      slug: slugify(data.name),
+      description: data.description,
+      lat: data.lat,
+      long: data.long,
+      userId: session.user.id,
+    })
+    .returning();
+
+  return newLocation;
+});


### PR DESCRIPTION
## Summary
- add POST API endpoint to insert locations into DB
- add GET API endpoint to list user locations
- hook location form to backend and refresh results

## Testing
- `pnpm lint` *(fails: Request was cancelled because network access is restricted)*

------
https://chatgpt.com/codex/tasks/task_e_68484574896083309779f80b1c0581d9