### PR TITLE
Replace deprecated text-muted class

### DIFF
--- a/pages/dashboard/locations/index.vue
+++ b/pages/dashboard/locations/index.vue
@@ -229,7 +229,7 @@ async function submit() {
               <i class="bi bi-geo-alt-fill text-primary" />
               {{ loc.name }}
             </h2>
-            <p class="text-sm text-muted">
+            <p class="text-sm text-base-content/60">
               {{ loc.description }}
             </p>
             <p class="text-sm">


### PR DESCRIPTION
## Summary
- replace `text-muted` with `text-base-content/60` in dashboard locations

## Testing
- `pnpm lint` *(fails: unable to fetch pnpm)*

------
https://chatgpt.com/codex/tasks/task_e_68484f753c4c83308b57de1eee157e2a