### PR TITLE
Improve session handling

### DIFF
--- a/plugins/init-auth.client.ts
+++ b/plugins/init-auth.client.ts
@@ -1,4 +1,0 @@
-export default defineNuxtPlugin(async () => {
-  const authStore = useAuthStore();
-  await authStore.init();
-});

--- a/plugins/init-auth.ts
+++ b/plugins/init-auth.ts
@@ -1,0 +1,5 @@
+export default defineNuxtPlugin(async () => {
+  const authStore = useAuthStore();
+  const serverSession = useState<any>("session");
+  await authStore.init(serverSession.value);
+});

--- a/server/middleware/session.ts
+++ b/server/middleware/session.ts
@@ -1,0 +1,9 @@
+import { auth } from "~/lib/auth";
+
+export default defineEventHandler(async (event) => {
+  const sessionState = useState("session");
+  if (sessionState.value === undefined) {
+    sessionState.value = await auth.api.getSession({ headers: event.headers });
+  }
+  event.context.session = sessionState.value;
+});

--- a/stores/auth.ts
+++ b/stores/auth.ts
@@ -5,7 +5,15 @@ const authClient = createAuthClient();
 export const useAuthStore = defineStore("useAuthStore", () => {
   const session = ref<Awaited<ReturnType<typeof authClient.useSession>> | null>(null);
 
-  async function init() {
+  function setSession(data: Awaited<ReturnType<typeof authClient.useSession>> | null) {
+    session.value = data;
+  }
+
+  async function init(initial?: any) {
+    if (initial) {
+      session.value = { data: initial, isPending: false } as any;
+      return;
+    }
     const data = await authClient.useSession(useFetch);
     session.value = data;
   }
@@ -22,11 +30,13 @@ export const useAuthStore = defineStore("useAuthStore", () => {
 
   async function signOut() {
     await authClient.signOut();
+    session.value = null;
     navigateTo("/");
   }
 
   return {
     init,
+    setSession,
     user,
     loading,
     signIn,


### PR DESCRIPTION
## Summary
- save user session in a new server middleware so every request has it available
- initialise the auth store with the server-provided session
- allow setting session directly in the auth store and clear it on sign out

## Testing
- `pnpm lint` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.10.0.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_68486314d1d48330a74f4c6eefc53e14