### PR TITLE
Remove redundant session middleware

### DIFF
--- a/plugins/init-auth.ts
+++ b/plugins/init-auth.ts
@@ -1,5 +1,4 @@
 export default defineNuxtPlugin(async () => {
   const authStore = useAuthStore();
-  const serverSession = useState<any>("session");
-  await authStore.init(serverSession.value);
+  await authStore.init();
 });

--- a/server/middleware/session.ts
+++ b/server/middleware/session.ts
@@ -1,9 +1,0 @@
-import { auth } from "~/lib/auth";
-
-export default defineEventHandler(async (event) => {
-  const sessionState = useState("session");
-  if (sessionState.value === undefined) {
-    sessionState.value = await auth.api.getSession({ headers: event.headers });
-  }
-  event.context.session = sessionState.value;
-});


### PR DESCRIPTION
## Summary
- remove session middleware and rely on auth middleware
- simplify `init-auth` plugin to fetch the session directly

## Testing
- `pnpm lint` *(fails: unable to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684866862d60833085de870be20b5584