### PR TITLE
Fix Add Location modal close behavior

### DIFF
--- a/components/form/add-location.vue
+++ b/components/form/add-location.vue
@@ -3,22 +3,20 @@ import { toTypedSchema } from "@vee-validate/zod";
 
 import { InsertLocation } from "~/lib/db/schema";
 
-const { handleSubmit, errors } = useForm({
+const emit = defineEmits<{ (e: "close"): void }>();
+
+const { handleSubmit, errors, resetForm } = useForm({
   validationSchema: toTypedSchema(InsertLocation),
 });
 const onSubmit = handleSubmit((values) => {
   console.log("Form submitted with values:", values);
+  closeModal();
 });
 
-effect(() => {
-  console.error(toRaw(errors.value));
-});
 
 function closeModal() {
-
-  // resetForm();
-  // router.replace("/dashboard/locations");
-  // resetForm();
+  emit("close");
+  resetForm();
 }
 </script>
 


### PR DESCRIPTION
## Summary
- add emitted `close` event for AddLocation form
- reset form when closing the modal
- call `closeModal` after submit
- remove debug error log

## Testing
- `pnpm lint` *(fails: Request was cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_68493d0826fc8330a234db8311bd63fe